### PR TITLE
feat: add footer with log and links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,0 @@
-const Footer = () => {
-  return <div>Footer</div>;
-};
-
-export default Footer;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,7 +1,8 @@
 import { FC, PropsWithChildren } from "react";
-import Footer from "./Footer";
-import NavigationBar from "./NavigationBar";
+
 import { Inter } from "next/font/google";
+import NavigationBar from "./NavigationBar";
+import SiteFooter from "./SiteFooter";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -14,7 +15,7 @@ const Layout: FC<PropsWithChildren<{}>> = ({ children }) => {
       >
         {children}
       </main>
-      <Footer />
+      <SiteFooter />
     </>
   );
 };

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,0 +1,38 @@
+import { FC } from "react";
+import { Footer } from "flowbite-react";
+import Link from "next/link";
+
+const SiteFooter: FC = () => {
+  return (
+    <Footer container={true}>
+      <div className="w-full text-center">
+        <div className="w-full justify-between sm:flex sm:items-center sm:justify-between">
+          <Footer.Brand
+            href="/"
+            src="https://flowbite.com/docs/images/logo.svg"
+            alt="Japan Tour Guide Agency - Logo"
+            name="JTGA"
+          />
+          <Footer.LinkGroup>
+            <Footer.Link href="/about" as={Link}>
+              About
+            </Footer.Link>
+            <Footer.Link href="#" as={Link}>
+              Privacy Policy
+            </Footer.Link>
+            <Footer.Link href="#" as={Link}>
+              Licensing
+            </Footer.Link>
+            <Footer.Link href="/contact" as={Link}>
+              Contact
+            </Footer.Link>
+          </Footer.LinkGroup>
+        </div>
+        <Footer.Divider />
+        <Footer.Copyright href="/" by="JTGA" year={new Date().getFullYear()} />
+      </div>
+    </Footer>
+  );
+};
+
+export default SiteFooter;


### PR DESCRIPTION
Added a footer with a flowbite logo and some links

<img width="744" alt="image" src="https://github.com/atcheri/japantourguideagency.com-nextjs/assets/1909176/0cf0e785-33d4-48c1-9ec2-07ffb00ecf00">
